### PR TITLE
Add Cloudflare Workers deployment

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,16 @@
+# Copy this file to .dev.vars for `pnpm worker:dev`.
+TMDB_API_KEY=
+
+F2MEDIA_BASEURL=
+
+PEEPBOXTV_BASEURL=
+PEEPBOXTV_USER_ID=
+PEEPBOXTV_ANDROID_ID=
+PEEPBOXTV_API_KEY=
+
+# Set this to true to proxy metadata images through this same Worker.
+PROXY_ENABLE=false
+# Optional in Workers: defaults to the current Worker origin.
+PROXY_URL=
+PROXY_PATH=proxy
+PROXY_ALLOWED_URLS=metahub.space,imdb.com,strem.io,tmdb.org

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ node_modules
 coverage
 
 .env
+.dev.vars
+.dev.vars.*
+!.dev.vars.example
+.wrangler
 .idea
 
 t1.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.source="https://github.com/MrMohebi/stremio-ir-pr
 ENV NODE_ENV=production
 WORKDIR /home/node/app
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable && pnpm install --frozen-lockfile --prod
 
 COPY --chown=node:node . .

--- a/README.md
+++ b/README.md
@@ -52,4 +52,15 @@ pnpm dev
 
 The addon listens on `http://127.0.0.1:7000` by default. Set `PORT` to override it.
 
+## Cloudflare Workers
+
+The addon and proxy can also run together in one Cloudflare Worker:
+
+```sh
+cp .dev.vars.example .dev.vars
+pnpm worker:dev
+```
+
+Use `pnpm worker:deploy` to publish it. See [Deploying to Cloudflare Workers](docs/CLOUDFLARE.md) for secrets, proxy configuration, local testing, and deployment details. The existing Node.js and Docker deployments remain unchanged.
+
 To integrate another streaming source, see [Adding a New Provider](docs/ADDING-A-PROVIDER.md).

--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ import {ID_SEPARATOR, METADATA_SOURCE} from './sources/source.js'
 import {getCinemeta, getSubtitle, modifyUrls} from './utils.js'
 
 export const ADDON_PREFIX = 'ip'
-export const ADDON_VERSION = '2.3.0'
+export const ADDON_VERSION = '2.4.0'
 
 const CATALOGS = [
     {key: 'f2media', name: 'F2Media'},

--- a/cloudflare/http-client.js
+++ b/cloudflare/http-client.js
@@ -1,0 +1,93 @@
+function appendParams(url, params) {
+    const result = new URL(url)
+    for (const [key, value] of Object.entries(params ?? {})) {
+        if (value != null) {
+            result.searchParams.append(key, String(value))
+        }
+    }
+    return result.toString()
+}
+
+function requestHeaders(values = {}) {
+    const headers = new Headers()
+    for (const [key, value] of Object.entries(values)) {
+        if (value != null && key.toLowerCase() !== 'host') {
+            headers.set(key, String(value))
+        }
+    }
+    return headers
+}
+
+async function responseData(response, responseType) {
+    if (responseType === 'arraybuffer') {
+        return response.arrayBuffer()
+    }
+
+    const body = await response.text()
+    if (!body) {
+        return ''
+    }
+    try {
+        return JSON.parse(body)
+    } catch {
+        return body
+    }
+}
+
+async function fetchRequest(fetcher, method, url, data, config = {}) {
+    const controller = new AbortController()
+    const timeout = Number(config.timeout)
+    const timer = Number.isFinite(timeout) && timeout > 0
+        ? setTimeout(() => controller.abort(), timeout)
+        : null
+    const headers = requestHeaders(config.headers)
+    let body
+
+    if (data != null) {
+        if (typeof data === 'string' || data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+            body = data
+        } else {
+            body = JSON.stringify(data)
+            if (!headers.has('content-type')) {
+                headers.set('content-type', 'application/json')
+            }
+        }
+    }
+
+    try {
+        const response = await fetcher(appendParams(url, config.params), {
+            method,
+            headers,
+            body,
+            redirect: config.maxRedirects === 0 ? 'manual' : 'follow',
+            signal: controller.signal,
+        })
+        const result = {
+            status: response.status,
+            headers: Object.fromEntries(response.headers),
+            data: await responseData(response, config.responseType),
+        }
+        const validateStatus = config.validateStatus ?? ((status) => status >= 200 && status < 300)
+        if (!validateStatus(response.status)) {
+            const error = new Error(`Request failed with status code ${response.status}`)
+            error.response = result
+            throw error
+        }
+        return result
+    } finally {
+        if (timer) {
+            clearTimeout(timer)
+        }
+    }
+}
+
+export function createFetchHttpClient(fetcher = fetch) {
+    return {
+        get(url, config) {
+            return fetchRequest(fetcher, 'GET', url, null, config)
+        },
+        post(url, data, config) {
+            return fetchRequest(fetcher, 'POST', url, data, config)
+        },
+    }
+}

--- a/cloudflare/index.js
+++ b/cloudflare/index.js
@@ -1,0 +1,3 @@
+import {createWorkerHandler} from './worker.js'
+
+export default {fetch: createWorkerHandler()}

--- a/cloudflare/proxy.js
+++ b/cloudflare/proxy.js
@@ -1,0 +1,103 @@
+const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024
+const DEFAULT_MAX_REDIRECTS = 5
+const PROXY_TIMEOUT_MS = 30_000
+
+function httpError(message, statusCode) {
+    return Object.assign(new Error(message), {statusCode})
+}
+
+export function createWorkerProxyConfig(env = {}) {
+    return {
+        path: String(env.PROXY_PATH || 'proxy').replace(/^\/+|\/+$/g, '') || 'proxy',
+        allowedDomains: String(env.PROXY_ALLOWED_URLS || 'metahub.space,imdb.com,strem.io,tmdb.org')
+            .split(',')
+            .map((domain) => domain.trim().toLowerCase())
+            .filter(Boolean),
+        maxFileSize: DEFAULT_MAX_FILE_SIZE,
+        maxRedirects: DEFAULT_MAX_REDIRECTS,
+    }
+}
+
+export function validateWorkerProxyUrl(value, allowedDomains) {
+    let url
+    try {
+        url = new URL(value)
+    } catch {
+        throw httpError('Invalid URL', 400)
+    }
+    if (!['http:', 'https:'].includes(url.protocol)) {
+        throw httpError('Only HTTP and HTTPS URLs are supported', 400)
+    }
+
+    const hostname = url.hostname.toLowerCase()
+    const allowed = allowedDomains.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`))
+    if (!allowed) {
+        throw httpError('Access to the specified domain is not allowed', 403)
+    }
+    return url
+}
+
+async function fetchWithTimeout(fetcher, url) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS)
+    try {
+        return await fetcher(url, {redirect: 'manual', signal: controller.signal})
+    } finally {
+        clearTimeout(timer)
+    }
+}
+
+export async function fetchAllowedResource(targetUrl, config, fetcher = fetch) {
+    let currentUrl = validateWorkerProxyUrl(targetUrl, config.allowedDomains)
+
+    for (let redirectCount = 0; redirectCount <= config.maxRedirects; redirectCount += 1) {
+        const response = await fetchWithTimeout(fetcher, currentUrl.toString())
+        if (response.status >= 300 && response.status < 400) {
+            const location = response.headers.get('location')
+            if (redirectCount === config.maxRedirects || !location) {
+                throw httpError('Too many or invalid redirects', 502)
+            }
+            currentUrl = validateWorkerProxyUrl(new URL(location, currentUrl).toString(), config.allowedDomains)
+            continue
+        }
+        if (!response.ok) {
+            throw httpError(`Upstream request failed with status ${response.status}`, 502)
+        }
+
+        const contentLength = Number(response.headers.get('content-length'))
+        if (Number.isFinite(contentLength) && contentLength > config.maxFileSize) {
+            throw httpError('File size exceeds the allowed limit of 10MB', 413)
+        }
+        const body = await response.arrayBuffer()
+        if (body.byteLength > config.maxFileSize) {
+            throw httpError('File size exceeds the allowed limit of 10MB', 413)
+        }
+        return {body, headers: response.headers}
+    }
+
+    throw httpError('Too many redirects', 502)
+}
+
+export async function handleProxyRequest(request, env, fetcher = fetch, logger = console) {
+    const config = createWorkerProxyConfig(env)
+    const targetUrl = new URL(request.url).searchParams.get('url')
+    if (!targetUrl) {
+        return new Response('URL parameter is required', {status: 400})
+    }
+
+    try {
+        const result = await fetchAllowedResource(targetUrl, config, fetcher)
+        const headers = new Headers()
+        for (const name of ['content-type', 'cache-control']) {
+            const value = result.headers.get(name)
+            if (value) {
+                headers.set(name, value)
+            }
+        }
+        return new Response(result.body, {headers})
+    } catch (error) {
+        const statusCode = error.statusCode || 502
+        logger.error('Proxy request failed', {message: error?.message ?? String(error), statusCode})
+        return new Response(error?.message || 'Error fetching the resource', {status: statusCode})
+    }
+}

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,0 +1,310 @@
+import F2Media from '../sources/f2media.js'
+import Peepboxtv from '../sources/peepboxtv.js'
+import {ID_SEPARATOR, METADATA_SOURCE} from '../sources/source.js'
+import {modifyUrls} from '../utils.js'
+import {createFetchHttpClient} from './http-client.js'
+import {createWorkerProxyConfig, handleProxyRequest} from './proxy.js'
+
+const ADDON_PREFIX = 'ip'
+const ADDON_VERSION = '2.4.0'
+
+const CATALOGS = [
+    {key: 'f2media', name: 'F2Media'},
+    {key: 'peepboxtv', name: 'PeepBoxTv'},
+]
+const CORS_HEADERS = {
+    'access-control-allow-headers': 'Content-Type',
+    'access-control-allow-methods': 'GET, HEAD, OPTIONS',
+    'access-control-allow-origin': '*',
+}
+
+export function createWorkerLogger(env = {}) {
+    const levels = ['error', 'warn', 'info', 'debug']
+    const configuredLevel = levels.includes(env.LOG_LEVEL) ? env.LOG_LEVEL : 'info'
+    const threshold = levels.indexOf(configuredLevel)
+    return Object.fromEntries(levels.map((level, index) => [
+        level,
+        (message, details) => {
+            if (index <= threshold) {
+                console[level](message, details ?? '')
+            }
+        },
+    ]))
+}
+
+export function createWorkerManifest(env = {}) {
+    const developmentSuffix = env.DEV_MODE === 'true' ? ' - DEV' : ''
+    return {
+        id: 'org.mmmohebi.stremioIrProviders',
+        version: ADDON_VERSION,
+        contactEmail: 'mmmohebi@outlook.com',
+        description: 'Stream movies and series from Iranian providers. Source: https://github.com/MrMohebi/stremio-ir-providers',
+        logo: 'https://raw.githubusercontent.com/MrMohebi/stremio-ir-providers/refs/heads/master/logo.png',
+        name: `Iran Provider${developmentSuffix}`,
+        catalogs: CATALOGS.flatMap(({key, name}) => ['movie', 'series'].map((type) => ({
+            name: `${name}${developmentSuffix}`,
+            type,
+            id: `${key}_${type === 'movie' ? 'movies' : 'series'}`,
+            extra: [{name: 'search', isRequired: true}],
+        }))),
+        resources: [
+            'catalog',
+            {name: 'meta', types: ['series', 'movie'], idPrefixes: [ADDON_PREFIX]},
+            {name: 'stream', types: ['series', 'movie'], idPrefixes: [ADDON_PREFIX]},
+            {name: 'subtitles', types: ['series', 'movie'], idPrefixes: [ADDON_PREFIX]},
+        ],
+        types: ['movie', 'series'],
+    }
+}
+
+export function createWorkerProviders({env = {}, logger = console, httpClient} = {}) {
+    return [
+        new F2Media(env.F2MEDIA_BASEURL, logger, httpClient, env),
+        new Peepboxtv(env.PEEPBOXTV_BASEURL, logger, httpClient, env),
+    ]
+}
+
+export function parseWorkerAddonId(id, providers) {
+    const parts = String(id ?? '').split(ID_SEPARATOR)
+    const provider = providers.find((item) => parts[0] === `${ADDON_PREFIX}${item.key}`)
+    if (!provider || !parts[1]) {
+        return null
+    }
+    return {
+        provider,
+        providerItemId: parts[1],
+        videoId: parts.slice(2).join(ID_SEPARATOR) || null,
+    }
+}
+
+function json(value, status = 200) {
+    return new Response(JSON.stringify(value), {
+        status,
+        headers: {'content-type': 'application/json; charset=utf-8'},
+    })
+}
+
+function withCors(response, headOnly = false) {
+    const headers = new Headers(response.headers)
+    for (const [name, value] of Object.entries(CORS_HEADERS)) {
+        headers.set(name, value)
+    }
+    return new Response(headOnly ? null : response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    })
+}
+
+function decoded(value) {
+    try {
+        return decodeURIComponent(value)
+    } catch {
+        return null
+    }
+}
+
+function findCatalogProvider(catalogId, providers) {
+    return providers.find((provider) => catalogId === `${provider.key}_movies` || catalogId === `${provider.key}_series`)
+}
+
+function proxyPrefix(env, requestUrl) {
+    const baseUrl = String(env.PROXY_URL || new URL(requestUrl).origin).replace(/\/$/, '')
+    const path = createWorkerProxyConfig(env).path
+    return `${baseUrl}/${path}?url=`
+}
+
+function logResourceError(logger, resource, error) {
+    logger.error(`${resource} request failed`, {message: error?.message ?? String(error)})
+}
+
+async function getCinemeta(type, imdbId, httpClient) {
+    if (!imdbId) {
+        return null
+    }
+    try {
+        const response = await httpClient.get(
+            `https://v3-cinemeta.strem.io/meta/${type}/${encodeURIComponent(imdbId)}.json`,
+            {timeout: 15_000},
+        )
+        return response.data ?? null
+    } catch {
+        return null
+    }
+}
+
+async function getSubtitle(type, imdbId, httpClient) {
+    if (!imdbId) {
+        return {subtitles: []}
+    }
+    try {
+        const response = await httpClient.get(
+            `https://opensubtitles-v3.strem.io/subtitles/${type}/${encodeURIComponent(imdbId)}.json`,
+            {timeout: 15_000},
+        )
+        return response.data ?? {subtitles: []}
+    } catch {
+        return {subtitles: []}
+    }
+}
+
+async function catalogResponse(route, providers, logger) {
+    try {
+        const provider = findCatalogProvider(route.id, providers)
+        const search = new URLSearchParams(route.extraArgs ?? '').get('search')?.trim()
+        if (!provider || !search || !['movie', 'series'].includes(route.type)) {
+            return json({metas: []})
+        }
+        const results = await provider.search(search)
+        const metas = (Array.isArray(results) ? results : [])
+            .filter((item) => item?.id != null && item.type === route.type)
+            .map((item) => ({...item, id: `${ADDON_PREFIX}${provider.providerID}${item.id}`}))
+        return json({metas})
+    } catch (error) {
+        logResourceError(logger, 'Catalog', error)
+        return json({metas: []})
+    }
+}
+
+async function metaResponse(route, providers, services, env, requestUrl, logger) {
+    try {
+        const parsedId = parseWorkerAddonId(route.id, providers)
+        if (!parsedId || !['movie', 'series'].includes(route.type)) {
+            return json({})
+        }
+        const movieData = await parsedId.provider.getMovieData(route.type, parsedId.providerItemId)
+        if (!movieData) {
+            return json({})
+        }
+
+        const upstreamMeta = parsedId.provider.metadataSource === METADATA_SOURCE.PROVIDER
+            ? {meta: await parsedId.provider.getMeta(route.type, parsedId.providerItemId, movieData)}
+            : await services.getCinemeta(route.type, await parsedId.provider.imdbID(movieData, route.type))
+        if (!upstreamMeta?.meta) {
+            return json({})
+        }
+        let result = structuredClone(upstreamMeta)
+        if (env.PROXY_ENABLE === 'true' || env.PROXY_ENABLE === '1') {
+            result = modifyUrls(result, proxyPrefix(env, requestUrl))
+        }
+
+        if (route.type === 'series') {
+            const videos = Array.isArray(result.meta.videos) ? result.meta.videos : []
+            result.meta.videos = videos
+                .filter((video) => video?.id)
+                .map((video) => ({
+                    ...video,
+                    id: `${ADDON_PREFIX}${parsedId.provider.providerID}${parsedId.providerItemId}${ID_SEPARATOR}${video.id}`,
+                }))
+            result.meta.id = route.id
+        } else {
+            result.meta.id = `${ADDON_PREFIX}${parsedId.provider.providerID}${parsedId.providerItemId}${ID_SEPARATOR}${result.meta.id}`
+            result.meta.behaviorHints = {
+                ...(result.meta.behaviorHints ?? {}),
+                defaultVideoId: result.meta.id,
+            }
+        }
+        return json(result)
+    } catch (error) {
+        logResourceError(logger, 'Meta', error)
+        return json({})
+    }
+}
+
+async function streamResponse(route, providers, logger) {
+    try {
+        const parsedId = parseWorkerAddonId(route.id, providers)
+        if (!parsedId || !['movie', 'series'].includes(route.type)) {
+            return json({streams: []})
+        }
+        const movieData = await parsedId.provider.getMovieData(route.type, parsedId.providerItemId)
+        const streams = movieData
+            ? parsedId.provider.getLinks(route.type, parsedId.videoId, movieData)
+            : []
+        return json({streams: Array.isArray(streams) ? streams : []})
+    } catch (error) {
+        logResourceError(logger, 'Stream', error)
+        return json({streams: []})
+    }
+}
+
+async function subtitleResponse(route, providers, services, logger) {
+    try {
+        const parsedId = parseWorkerAddonId(route.id, providers)
+        if (!parsedId || !parsedId.videoId || !['movie', 'series'].includes(route.type)) {
+            return json({subtitles: []})
+        }
+        const result = await services.getSubtitle(route.type, parsedId.videoId)
+        return json(result?.subtitles ? result : {subtitles: []})
+    } catch (error) {
+        logResourceError(logger, 'Subtitle', error)
+        return json({subtitles: []})
+    }
+}
+
+function matchRoute(pathname) {
+    const resource = pathname.match(/^\/(meta|stream)\/([^/]+)\/([^/]+)\.json$/)
+    if (resource) {
+        return {resource: resource[1], type: decoded(resource[2]), id: decoded(resource[3])}
+    }
+    const variable = pathname.match(/^\/(catalog|subtitles)\/([^/]+)\/([^/]+)(?:\/(.*))?\.json$/)
+    if (variable) {
+        return {
+            resource: variable[1],
+            type: decoded(variable[2]),
+            id: decoded(variable[3]),
+            extraArgs: decoded(variable[4] ?? ''),
+        }
+    }
+    return null
+}
+
+export function createWorkerHandler(options = {}) {
+    return async function workerFetch(request, env = {}) {
+        const logger = options.logger ?? createWorkerLogger(env)
+        try {
+            if (request.method === 'OPTIONS') {
+                return withCors(new Response(null, {status: 204}))
+            }
+            if (!['GET', 'HEAD'].includes(request.method)) {
+                return withCors(new Response('Method Not Allowed', {status: 405}))
+            }
+
+            const url = new URL(request.url)
+            const headOnly = request.method === 'HEAD'
+            let response
+            if (url.pathname === '/manifest.json') {
+                response = json(createWorkerManifest(env))
+            } else if (url.pathname === '/health') {
+                response = new Response('ok', {headers: {'content-type': 'text/plain; charset=utf-8'}})
+            } else if (url.pathname === `/${createWorkerProxyConfig(env).path}`) {
+                response = await handleProxyRequest(request, env, options.fetcher ?? fetch, logger)
+            } else {
+                const route = matchRoute(url.pathname)
+                if (!route || Object.values(route).some((value) => value === null)) {
+                    response = new Response('Not Found', {status: 404})
+                } else {
+                    const httpClient = options.httpClient ?? createFetchHttpClient(options.fetcher ?? fetch)
+                    const providers = options.providers ?? createWorkerProviders({env, logger, httpClient})
+                    const services = options.services ?? {
+                        getCinemeta: (type, id) => getCinemeta(type, id, httpClient),
+                        getSubtitle: (type, id) => getSubtitle(type, id, httpClient),
+                    }
+                    if (route.resource === 'catalog') {
+                        response = await catalogResponse(route, providers, logger)
+                    } else if (route.resource === 'meta') {
+                        response = await metaResponse(route, providers, services, env, request.url, logger)
+                    } else if (route.resource === 'stream') {
+                        response = await streamResponse(route, providers, logger)
+                    } else {
+                        response = await subtitleResponse(route, providers, services, logger)
+                    }
+                }
+            }
+            return withCors(response, headOnly)
+        } catch (error) {
+            logger.error('Unhandled Worker request error', {message: error?.message ?? String(error)})
+            return withCors(json({error: 'Internal Server Error'}, 500))
+        }
+    }
+}

--- a/docs/CLOUDFLARE.md
+++ b/docs/CLOUDFLARE.md
@@ -1,0 +1,77 @@
+# Deploying to Cloudflare Workers
+
+The Cloudflare entrypoint serves the complete Stremio addon and the image proxy from one Worker. The existing Node.js, Docker, and standalone proxy commands are unchanged.
+
+## Local development
+
+```sh
+corepack enable
+pnpm install
+cp .dev.vars.example .dev.vars
+pnpm worker:dev
+```
+
+Fill in `.dev.vars` with the provider configuration you use. Wrangler serves the addon at the URL shown in the terminal; append `/manifest.json` to install it in Stremio.
+
+`.dev.vars` is ignored by Git. Do not commit API keys or provider credentials.
+
+## Deploy
+
+Authenticate Wrangler once:
+
+```sh
+pnpm wrangler login
+```
+
+Store deployed credentials as encrypted Worker secrets. Set only the values required by the providers you enable:
+
+```sh
+pnpm wrangler secret put TMDB_API_KEY
+pnpm wrangler secret put F2MEDIA_BASEURL
+pnpm wrangler secret put PEEPBOXTV_BASEURL
+pnpm wrangler secret put PEEPBOXTV_USER_ID
+pnpm wrangler secret put PEEPBOXTV_ANDROID_ID
+pnpm wrangler secret put PEEPBOXTV_API_KEY
+```
+
+Then deploy:
+
+```sh
+pnpm worker:check
+pnpm worker:deploy
+```
+
+The deployed manifest URL is `https://stremio-ir-providers.<your-subdomain>.workers.dev/manifest.json`, unless you attach a custom domain or rename the Worker in `wrangler.jsonc`.
+
+## Enable the built-in proxy
+
+In `wrangler.jsonc`, set `PROXY_ENABLE` to `true`. The Worker automatically uses its current public origin, so `PROXY_URL` is normally unnecessary. Set `PROXY_URL` only when proxy traffic should use a different public hostname.
+
+`PROXY_ALLOWED_URLS` is a comma-separated allowlist. A hostname must exactly match an entry or be its subdomain. Add any provider image host that is not covered by the defaults; do not use an unrestricted or user-controlled domain.
+
+The proxy route defaults to:
+
+```text
+/proxy?url=https%3A%2F%2Fallowed.example%2Fimage.jpg
+```
+
+It accepts only HTTP(S), checks every redirect against the allowlist, limits responses to 10 MB, and forwards the upstream `Content-Type` and `Cache-Control` headers.
+
+## Configuration reference
+
+| Variable | Purpose |
+| --- | --- |
+| `F2MEDIA_BASEURL` | F2Media website base URL |
+| `TMDB_API_KEY` | TMDB fallback when F2Media has no IMDb ID |
+| `PEEPBOXTV_BASEURL` | PeepBoxTV API base URL |
+| `PEEPBOXTV_USER_ID` | PeepBoxTV account user ID |
+| `PEEPBOXTV_ANDROID_ID` | PeepBoxTV device ID |
+| `PEEPBOXTV_API_KEY` | PeepBoxTV API credential |
+| `DEV_MODE` | Adds `- DEV` to catalog and addon names when `true` |
+| `LOG_LEVEL` | `error`, `warn`, `info`, or `debug` |
+| `PROXY_ENABLE` | Rewrites metadata artwork through the Worker proxy |
+| `PROXY_URL` | Optional external proxy origin |
+| `PROXY_PATH` | Proxy route name; defaults to `proxy` |
+| `PROXY_ALLOWED_URLS` | Comma-separated proxy hostname allowlist |
+
+Cloudflare configuration is in `wrangler.jsonc`. Its `nodejs_compat` flag supports dependencies used by the provider parsers, while incoming requests and proxy requests use the Worker-native Fetch API.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stremio-ir-providers",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "packageManager": "pnpm@11.11.0",
   "main": "index.js",
   "type": "module",
@@ -9,6 +9,9 @@
     "dev-proxy": "node --env-file=.env ./proxyServer.js",
     "start": "node ./index.js",
     "start-proxy": "node ./proxyServer.js",
+    "worker:dev": "wrangler dev",
+    "worker:deploy": "wrangler deploy",
+    "worker:check": "wrangler deploy --dry-run",
     "test": "node --test",
     "check": "node --test && node --check index.js && node --check proxyServer.js"
   },
@@ -25,5 +28,8 @@
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "winston": "^3.19.0"
+  },
+  "devDependencies": {
+    "wrangler": "^4.112.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,18 +23,407 @@ importers:
       winston:
         specifier: ^3.19.0
         version: 3.19.0
+    devDependencies:
+      wrangler:
+        specifier: ^4.112.0
+        version: 4.112.0
 
 packages:
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260714.1':
+    resolution: {integrity: sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260714.1':
+    resolution: {integrity: sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260714.1':
+    resolution: {integrity: sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260714.1':
+    resolution: {integrity: sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260714.1':
+    resolution: {integrity: sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -55,6 +444,9 @@ packages:
 
   axios@1.18.1:
     resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -122,6 +514,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -149,6 +545,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -192,6 +592,9 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -207,6 +610,11 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -249,6 +657,11 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -310,6 +723,10 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
@@ -344,6 +761,11 @@ packages:
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  miniflare@4.20260714.0:
+    resolution: {integrity: sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -386,8 +808,14 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -427,6 +855,11 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -437,6 +870,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -464,6 +901,10 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
@@ -475,6 +916,9 @@ packages:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
@@ -482,6 +926,9 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -511,12 +958,72 @@ packages:
     resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
     engines: {node: '>= 12.0.0'}
 
+  workerd@1.20260714.1:
+    resolution: {integrity: sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.112.0:
+    resolution: {integrity: sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260714.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
 snapshots:
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260714.1
+
+  '@cloudflare/workerd-darwin-64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260714.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260714.1':
+    optional: true
+
   '@colors/colors@1.6.0': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
@@ -524,10 +1031,214 @@ snapshots:
       enabled: 2.0.0
       kuler: 2.0.0
 
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
   '@so-ric/colorspace@1.1.6':
     dependencies:
       color: 5.0.3
       text-hex: 1.0.0
+
+  '@speed-highlight/core@1.2.17': {}
 
   '@types/triple-beam@1.3.5': {}
 
@@ -555,6 +1266,8 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  blake3-wasm@2.1.5: {}
 
   body-parser@2.3.0:
     dependencies:
@@ -636,6 +1349,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -658,6 +1373,8 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
+
+  detect-libc@2.1.2: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -700,6 +1417,8 @@ snapshots:
 
   entities@7.0.1: {}
 
+  error-stack-parser-es@1.0.5: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -714,6 +1433,35 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.4
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escape-html@1.0.3: {}
 
@@ -780,6 +1528,9 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -851,6 +1602,8 @@ snapshots:
 
   is-stream@2.0.1: {}
 
+  kleur@4.1.5: {}
+
   kuler@2.0.0: {}
 
   logform@2.7.0:
@@ -879,6 +1632,18 @@ snapshots:
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  miniflare@4.20260714.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260714.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   ms@2.1.3: {}
 
@@ -919,7 +1684,11 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-to-regexp@6.3.0: {}
+
   path-to-regexp@8.4.2: {}
+
+  pathe@2.0.3: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -964,6 +1733,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  semver@7.8.5: {}
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -990,6 +1761,37 @@ snapshots:
       - supports-color
 
   setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   side-channel-list@1.0.1:
     dependencies:
@@ -1027,11 +1829,16 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  supports-color@10.2.2: {}
+
   text-hex@1.0.0: {}
 
   toidentifier@1.0.1: {}
 
   triple-beam@1.4.1: {}
+
+  tslib@2.8.1:
+    optional: true
 
   type-is@2.1.0:
     dependencies:
@@ -1040,6 +1847,10 @@ snapshots:
       mime-types: 3.0.2
 
   undici@7.28.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unpipe@1.0.0: {}
 
@@ -1073,4 +1884,43 @@ snapshots:
       triple-beam: 1.4.1
       winston-transport: 4.9.0
 
+  workerd@1.20260714.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260714.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260714.1
+      '@cloudflare/workerd-linux-64': 1.20260714.1
+      '@cloudflare/workerd-linux-arm64': 1.20260714.1
+      '@cloudflare/workerd-windows-64': 1.20260714.1
+
+  wrangler@4.112.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260714.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 4.20260714.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260714.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true
+minimumReleaseAgeExclude:
+  - miniflare@4.20260714.0
+  - wrangler@4.112.0

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -55,7 +55,7 @@ function createTestApp(provider = createProvider(), options = {}) {
 test('manifest keeps the public addon contract', () => {
     const manifest = createManifest({DEV_MODE: 'true'})
     assert.equal(manifest.id, 'org.mmmohebi.stremioIrProviders')
-    assert.equal(manifest.version, '2.3.0')
+    assert.equal(manifest.version, '2.4.0')
     assert.equal(manifest.name, 'Iran Provider - DEV')
     assert.deepEqual(manifest.catalogs.map((catalog) => catalog.id), [
         'f2media_movies',

--- a/test/cloudflare-worker.test.js
+++ b/test/cloudflare-worker.test.js
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {createFetchHttpClient} from '../cloudflare/http-client.js'
+import {createWorkerHandler} from '../cloudflare/worker.js'
+import {fetchAllowedResource} from '../cloudflare/proxy.js'
+import {METADATA_SOURCE} from '../sources/source.js'
+import {silentLogger} from '../test-support/helpers.js'
+
+function createProvider(overrides = {}) {
+    return {
+        key: 'f2media',
+        providerID: 'f2media___',
+        metadataSource: METADATA_SOURCE.PROVIDER,
+        async search() {
+            return [{id: '10', name: 'Movie', type: 'movie'}]
+        },
+        async getMovieData() {
+            return {title: 'Movie'}
+        },
+        getMeta(type, id) {
+            return {
+                id,
+                type,
+                name: 'Movie',
+                poster: 'https://images.example/poster.jpg',
+            }
+        },
+        getLinks() {
+            return [{url: 'https://media.example/movie.mp4', title: '1080p'}]
+        },
+        ...overrides,
+    }
+}
+
+function createHandler(options = {}) {
+    return createWorkerHandler({
+        providers: [createProvider()],
+        logger: silentLogger,
+        services: {
+            async getCinemeta() {
+                return null
+            },
+            async getSubtitle() {
+                return {subtitles: [{id: 'sub-1', url: 'https://sub.example/file.srt'}]}
+            },
+        },
+        ...options,
+    })
+}
+
+test('Cloudflare Worker serves manifest, health, and CORS without Express', async () => {
+    const handler = createHandler()
+    const manifest = await handler(new Request('https://addon.example/manifest.json'), {})
+    assert.equal(manifest.status, 200)
+    assert.equal(manifest.headers.get('access-control-allow-origin'), '*')
+    assert.equal((await manifest.json()).id, 'org.mmmohebi.stremioIrProviders')
+
+    const health = await handler(new Request('https://addon.example/health'), {})
+    assert.equal(await health.text(), 'ok')
+
+    const preflight = await handler(new Request('https://addon.example/manifest.json', {method: 'OPTIONS'}), {})
+    assert.equal(preflight.status, 204)
+})
+
+test('Cloudflare Worker exposes catalog, metadata, stream, and subtitle routes', async () => {
+    const handler = createHandler()
+    const catalog = await handler(new Request(
+        'https://addon.example/catalog/movie/f2media_movies/search=Movie.json',
+    ), {})
+    assert.deepEqual(await catalog.json(), {
+        metas: [{id: 'ipf2media___10', name: 'Movie', type: 'movie'}],
+    })
+
+    const metadata = await handler(new Request('https://addon.example/meta/movie/ipf2media___10.json'), {})
+    const metaBody = await metadata.json()
+    assert.equal(metaBody.meta.id, 'ipf2media___10___10')
+    assert.equal(metaBody.meta.behaviorHints.defaultVideoId, metaBody.meta.id)
+
+    const stream = await handler(new Request('https://addon.example/stream/movie/ipf2media___10___10.json'), {})
+    assert.deepEqual(await stream.json(), {
+        streams: [{url: 'https://media.example/movie.mp4', title: '1080p'}],
+    })
+
+    const subtitles = await handler(new Request(
+        'https://addon.example/subtitles/movie/ipf2media___10___tt1234567.json',
+    ), {})
+    assert.deepEqual(await subtitles.json(), {
+        subtitles: [{id: 'sub-1', url: 'https://sub.example/file.srt'}],
+    })
+})
+
+test('Cloudflare metadata uses the current Worker origin for its built-in proxy', async () => {
+    const handler = createHandler()
+    const response = await handler(
+        new Request('https://addon.example/meta/movie/ipf2media___10.json'),
+        {PROXY_ENABLE: 'true', PROXY_PATH: '/asset/'},
+    )
+    assert.equal(
+        (await response.json()).meta.poster,
+        'https://addon.example/asset?url=https%3A%2F%2Fimages.example%2Fposter.jpg',
+    )
+})
+
+test('Cloudflare proxy rejects missing, disallowed, and oversized resources', async () => {
+    const handler = createHandler({
+        fetcher: async () => new Response(new Uint8Array(5), {
+            headers: {'content-type': 'image/png'},
+        }),
+    })
+    const missing = await handler(new Request('https://addon.example/proxy'), {
+        PROXY_ALLOWED_URLS: 'example.com',
+    })
+    assert.equal(missing.status, 400)
+
+    const denied = await handler(new Request(
+        `https://addon.example/proxy?url=${encodeURIComponent('https://evil.test/image.png')}`,
+    ), {PROXY_ALLOWED_URLS: 'example.com'})
+    assert.equal(denied.status, 403)
+
+    await assert.rejects(
+        fetchAllowedResource(
+            'https://example.com/image.png',
+            {allowedDomains: ['example.com'], maxRedirects: 1, maxFileSize: 4},
+            async () => new Response(new Uint8Array(5)),
+        ),
+        (error) => error.statusCode === 413,
+    )
+})
+
+test('Cloudflare proxy validates redirects and returns allowed binary content', async () => {
+    const requested = []
+    const handler = createHandler({
+        fetcher: async (url) => {
+            requested.push(String(url))
+            if (requested.length === 1) {
+                return new Response(null, {status: 302, headers: {location: '/final.png'}})
+            }
+            return new Response(new Uint8Array([1, 2, 3]), {
+                headers: {
+                    'content-type': 'image/png',
+                    'cache-control': 'public, max-age=60',
+                },
+            })
+        },
+    })
+    const response = await handler(new Request(
+        `https://addon.example/proxy?url=${encodeURIComponent('https://example.com/image.png')}`,
+    ), {PROXY_ALLOWED_URLS: 'example.com'})
+
+    assert.equal(response.status, 200)
+    assert.equal(response.headers.get('content-type'), 'image/png')
+    assert.equal(response.headers.get('cache-control'), 'public, max-age=60')
+    assert.deepEqual(new Uint8Array(await response.arrayBuffer()), new Uint8Array([1, 2, 3]))
+    assert.deepEqual(requested, ['https://example.com/image.png', 'https://example.com/final.png'])
+})
+
+test('Fetch HTTP client maps query parameters and strips the forbidden Host header', async () => {
+    let received
+    const client = createFetchHttpClient(async (url, init) => {
+        received = {url, init}
+        return Response.json({ok: true})
+    })
+    const response = await client.get('https://api.example/search', {
+        params: {q: 'a movie'},
+        headers: {Host: 'api.example', 'api-key': 'key'},
+        timeout: 1_000,
+    })
+
+    assert.equal(received.url, 'https://api.example/search?q=a+movie')
+    assert.equal(received.init.headers.has('host'), false)
+    assert.equal(received.init.headers.get('api-key'), 'key')
+    assert.deepEqual(response.data, {ok: true})
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,15 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "stremio-ir-providers",
+  "main": "./cloudflare/index.js",
+  "compatibility_date": "2026-07-16",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": true,
+  "vars": {
+    "LOG_LEVEL": "info",
+    "DEV_MODE": "false",
+    "PROXY_ENABLE": "true",
+    "PROXY_PATH": "proxy",
+    "PROXY_ALLOWED_URLS": "metahub.space,imdb.com,strem.io,tmdb.org"
+  }
+}


### PR DESCRIPTION
## Summary

- run the complete Stremio addon on Cloudflare Workers
- serve the allowlisted image proxy from the same Worker
- add Fetch-based provider requests, Wrangler configuration, and deployment documentation
- release the addon manifest as version 2.4.0

## Validation

- `pnpm check` (44 tests pass)
- `pnpm worker:check`
- local `workerd` smoke tests for `/health`, `/manifest.json`, and `/proxy`